### PR TITLE
Fix a typo and add state handling to covers/shades

### DIFF
--- a/MQTT app
+++ b/MQTT app
@@ -7355,7 +7355,19 @@ def commandP(name, state, payload, fullPayload, cmd, topic, json) { // 'set' com
                          mqtt.publishMsg("homie/${atomicState.normHubName}/${normalize(matchName)}/refresh", 'false', 1, false)
                 }  
         }    
-    }  
+    } else if (cmd == "state") {
+        if (matchDevice != null) {
+            // DUPLICATED TODO combine this as one method for all
+            log("Surmising required state [" + state + "] for " + name, "DEBUG")
+            CloseValues = "close"
+            OpenValues = "open"
+            if (CloseValues.contains(state.toLowerCase())) {
+                matchDevice.close()
+            } else if (OpenValues.contains(state.toLowerCase())) {
+                matchDevice.open()
+            } else log("Unknown state value " + state + " - need to add to lookup", "WARN")
+        }
+    }
    else log("No matching devices with this command available for ${cmd} for $name $state", "WARN")
   }
   else {    // json payload

--- a/MQTT app
+++ b/MQTT app
@@ -4510,7 +4510,7 @@ def otherDevices(evt, name=null, type=null, state=null, device=null, multiple=fa
 				category='position'
                 settable="true"
                 dType='shade'
-                HAtype="cover"subscribe to events from
+                HAtype="cover"
                 
                 mqtt.publishMsg (sTopic+'/'+category+'/$format','0:100',1,true,atomicState.suppress)
                 mqtt.publishMsg (sTopic+'/'+category+'/$datatype',"integer",1,true,atomicState.suppress)


### PR DESCRIPTION
There was some extra random text on line 4513 that killed the app when trying to add shades. 

The Ikea shades driver I'm using registers in the app as a shade instead of a cover (or maybe vice versa?) and adds a state topic for handling open/close commands. This wasn't handled so it threw a warning and ignored the command. The code is adapted from the contact cmd handler above to trigger the open and close commands of the shade driver.